### PR TITLE
.NET 8 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+src/.idea

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can customize the control using any of the below properties
 | HeaderStyle   | Label Style        | The header text can be styled as needed. By default, it uses the default font with FontSize of 24.      |
 | Theme   | Enum        | Defines the theme of the bottom sheet. It is based on enum values of Light and Dark. The bottom sheet color changes based on this theme (white for light theme and dark gray for Dark theme).      |
 | SheetHeight   | Double        | This defines the height of the content area of the bottom sheet.      |
+| CanBeDismissedByTappingOutside   | Boolean        | By default a user cannot tap outside the Bottom Sheet to dismiss it. Setting this property to true will enable a user to dismiss the Bottom Sheet by tapping outside of it.      |
 
 ## Running Example
 https://user-images.githubusercontent.com/103980/180698691-39030b2c-d79e-4412-9435-9590b8181b55.mp4

--- a/src/Maui.Controls.BottomSheet/BottomSheet.xaml
+++ b/src/Maui.Controls.BottomSheet/BottomSheet.xaml
@@ -34,6 +34,17 @@
                 <RowDefinition x:Name="BottomSheetRowDefinition" Height="{Binding Source={x:Reference BottomSheetControlRoot}, Path=SheetHeight, Mode=OneWay}" />
             </Grid.RowDefinitions>
 
+            <!-- Transparent area to close the sheet when tapped -->
+            <BoxView
+                x:Name="OutsideDismissArea"
+                Grid.Row="0"
+                IsVisible="{Binding Source={x:Reference BottomSheetControlRoot}, Path=CanBeDismissedByTappingOutside}"
+                BackgroundColor="Transparent">
+                <BoxView.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OutsideDismissArea_OnTapped" />
+                </BoxView.GestureRecognizers>
+            </BoxView>
+            
             <!-- Close Button -->
             <Image
                 x:Name="CloseBottomSheetButton"

--- a/src/Maui.Controls.BottomSheet/BottomSheet.xaml.cs
+++ b/src/Maui.Controls.BottomSheet/BottomSheet.xaml.cs
@@ -13,7 +13,7 @@ public partial class BottomSheet : ContentView
         nameof(CanBeDismissedByTappingOutside),
         typeof(bool),
         typeof(BottomSheet),
-        true,
+        false,
         BindingMode.OneWay,
         validateValue: (_, value) => value is bool,
         propertyChanged:

--- a/src/Maui.Controls.BottomSheet/BottomSheet.xaml.cs
+++ b/src/Maui.Controls.BottomSheet/BottomSheet.xaml.cs
@@ -8,6 +8,37 @@ public partial class BottomSheet : ContentView
     public IList<Microsoft.Maui.IView> BottomSheetContent => BottomSheetContentGrid.Children;
 
     #region Bindable Properties
+    
+    public static readonly BindableProperty CanBeDismissedByTappingOutsideProperty = BindableProperty.Create(
+        nameof(CanBeDismissedByTappingOutside),
+        typeof(bool),
+        typeof(BottomSheet),
+        true,
+        BindingMode.OneWay,
+        validateValue: (_, value) => value is bool,
+        propertyChanged:
+        (bindableObject, oldValue, newValue) =>
+        {
+            if (bindableObject is BottomSheet sheet && newValue is bool)
+            {
+                sheet.UpdateOutsideDismissArea();
+            }
+        });
+    
+    private void UpdateOutsideDismissArea()
+    {
+        if (OutsideDismissArea is not null)
+        {
+            OutsideDismissArea.IsVisible = CanBeDismissedByTappingOutside;
+            OutsideDismissArea.InputTransparent = !CanBeDismissedByTappingOutside;
+        }
+    }
+    
+    public bool CanBeDismissedByTappingOutside
+    {
+        get => (bool)GetValue(CanBeDismissedByTappingOutsideProperty);
+        set => SetValue(CanBeDismissedByTappingOutsideProperty, value);
+    }
 
     public static readonly BindableProperty SheetHeightProperty = BindableProperty.Create(
         nameof(SheetHeight),
@@ -126,4 +157,12 @@ public partial class BottomSheet : ContentView
 
     async void CloseBottomSheetButton_Tapped(System.Object sender, System.EventArgs e) =>
         await CloseBottomSheet();
+    
+    async void OutsideDismissArea_OnTapped(object sender, TappedEventArgs e)
+    {
+        if (CanBeDismissedByTappingOutside)
+        {
+            await CloseBottomSheet();
+        }
+    }
 }

--- a/src/Maui.Controls.BottomSheet/Maui.Controls.BottomSheet.csproj
+++ b/src/Maui.Controls.BottomSheet/Maui.Controls.BottomSheet.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net6.0;net6.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>disable</ImplicitUsings>
+		<RootNamespace>XGENO.Maui.Controls</RootNamespace>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
@@ -22,17 +24,6 @@
 	  <None Remove="Platforms\Windows\" />
 	  <None Remove="icnmenuclose.png" />
 	  <None Remove="icnmenuclosedark.png" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Folder Include="Platforms\Android\" />
-	  <Folder Include="Platforms\iOS\" />
-	  <Folder Include="Platforms\MacCatalyst\" />
-	  <Folder Include="Platforms\Windows\" />
-	</ItemGroup>
-	<ItemGroup>
-	  <MauiXaml Update="BottomSheet.xaml">
-	    <SubType></SubType>
-	  </MauiXaml>
 	</ItemGroup>
 	<ItemGroup>
 	  <EmbeddedResource Include="icnmenuclose.png">

--- a/src/Maui.Controls.BottomSheet/Maui.Controls.BottomSheet.csproj
+++ b/src/Maui.Controls.BottomSheet/Maui.Controls.BottomSheet.csproj
@@ -1,21 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net6.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-		<UseMaui>true</UseMaui>
+		<TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<RootNamespace>XGENO.Maui.Controls</RootNamespace>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+	</ItemGroup>
 
 	<ItemGroup>
 	  <None Remove="Platforms\Android\" />

--- a/src/TestApp/MainPage.xaml
+++ b/src/TestApp/MainPage.xaml
@@ -36,13 +36,23 @@
             <Button
                 Text="Dark Theme"
                 Clicked="DarkBottomSheet_Clicked" />
+            
+            <HorizontalStackLayout HorizontalOptions="Center" Spacing="8">
+                <Label Text="Auto-close by Tapping outside" VerticalOptions="Center">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="AutoDismissLabel_OnTapped" />
+                    </Label.GestureRecognizers>
+                </Label>
+                <Switch x:Name="autoDismiss" VerticalOptions="Center" />
+            </HorizontalStackLayout>
 
         </VerticalStackLayout>
 
         <!-- Simple Bottom Sheet -->
         <controls:BottomSheet
             x:Name="simpleBottomSheet"
-            HeaderText="Simple Example">
+            HeaderText="Simple Example"
+            CanBeDismissedByTappingOutside="{Binding IsToggled, Source={x:Reference autoDismiss}}">
             <controls:BottomSheet.BottomSheetContent>
                 <Label
                     Text="Hello from Bottom Sheet. This is a simple implementation with no customization."
@@ -56,7 +66,8 @@
         <controls:BottomSheet
             x:Name="customBottomSheet1"
             HeaderText="Custom Header Style"
-            HeaderStyle="{StaticResource BigRedStyle}">
+            HeaderStyle="{StaticResource BigRedStyle}"
+            CanBeDismissedByTappingOutside="{Binding IsToggled, Source={x:Reference autoDismiss}}">
             <controls:BottomSheet.BottomSheetContent>
                 <Label
                     Text="Look Ma! I can customize the header style of the Bottom Sheet."
@@ -70,7 +81,8 @@
         <controls:BottomSheet
             x:Name="customBottomSheet2"
             HeaderText="Custom Sheet Height"
-            SheetHeight="200">
+            SheetHeight="200"
+            CanBeDismissedByTappingOutside="{Binding IsToggled, Source={x:Reference autoDismiss}}">
             <controls:BottomSheet.BottomSheetContent>
                 <Label
                     Text="Now we have a Bottom Sheet with custom Sheet Height."
@@ -83,7 +95,8 @@
         <!-- Open and Close Bottom Sheet -->
         <controls:BottomSheet
             x:Name="customBottomSheet3"
-            HeaderText="Close Sheet Example">
+            HeaderText="Close Sheet Example"
+            CanBeDismissedByTappingOutside="{Binding IsToggled, Source={x:Reference autoDismiss}}">
             <controls:BottomSheet.BottomSheetContent>
                 <VerticalStackLayout
                     Spacing="24">
@@ -108,7 +121,8 @@
             x:Name="customBottomSheet4"
             HeaderText="Choose a Movie"
             HeaderStyle="{StaticResource BigRedStyle}"
-            SheetHeight="660">
+            SheetHeight="660"
+            CanBeDismissedByTappingOutside="{Binding IsToggled, Source={x:Reference autoDismiss}}">
             <controls:BottomSheet.BottomSheetContent>
                 <Grid
                     RowSpacing="16"
@@ -160,7 +174,8 @@
             x:Name="darkBottomSheet"
             HeaderText="Simple Example"
             HeaderStyle="{StaticResource BigDarkStyle}"
-            Theme="Dark">
+            Theme="Dark"
+            CanBeDismissedByTappingOutside="{Binding IsToggled, Source={x:Reference autoDismiss}}">
             <controls:BottomSheet.BottomSheetContent>
                 <Label
                     Text="Hello from Bottom Sheet. This is a bottom sheet with dark theme."

--- a/src/TestApp/MainPage.xaml.cs
+++ b/src/TestApp/MainPage.xaml.cs
@@ -42,6 +42,11 @@ public partial class MainPage : ContentPage
         await customBottomSheet4.CloseBottomSheet();
         await DisplayAlert("Selected Movie", $"You selected \"{selectedMovie.Title}\" from Year {selectedMovie.Year}. It was a great movie. Right?", "Yes, it was!");
     }
+
+    private void AutoDismissLabel_OnTapped(object sender, TappedEventArgs e)
+    {
+        autoDismiss.IsToggled = !autoDismiss.IsToggled;
+    }
 }
 
 

--- a/src/TestApp/MauiProgram.cs
+++ b/src/TestApp/MauiProgram.cs
@@ -16,4 +16,3 @@ public static class MauiProgram
 		return builder.Build();
 	}
 }
-

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-
+		<TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net6.0-android;net6.0-windows10.0.19041.0</TargetFrameworks>
+		
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TestApp</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net6.0-android;net6.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net8.0-android;net8.0-windows10.0.19041.0</TargetFrameworks>
 		
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TestApp</RootNamespace>
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
@@ -22,7 +21,7 @@
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
@@ -42,6 +41,10 @@
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Upgraded TargetFramework to .NET 8.
- Added support for user to auto-close Bottom Sheet by tapping outside the Bottom Sheet content. Functionality is disabled by default, and must be enabled by setting the CanBeDismissedByTappingOutside property to true.